### PR TITLE
remove specific version for pygame

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pygame
+pygame~=1.9
 pep8
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pygame==1.9.3
+pygame
 pep8
 pylint


### PR DESCRIPTION
Hey,

I tried to get your game running but got the error "freetype-config: Command not found"

```
Collecting pygame==1.9.3 (from -r ./requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/61/06/3c25051549c252cc6fde01c8aeae90b96831370884504fe428a623316def/pygame-1.9.3.tar.gz
    Complete output from command python setup.py egg_info:
    
    
    WARNING, No "Setup" File Exists, Running "config.py"
    Using UNIX configuration...
    
    /bin/sh: freetype-config: Command not found
    /bin/sh: freetype-config: Command not found
    /bin/sh: freetype-config: Command not found
    
    Hunting dependencies...
    WARNING: "freetype-config" failed!
    SDL     : found 1.2.15
    FONT    : not found
    IMAGE   : not found
    MIXER   : not found
    PNG     : found
    JPEG    : found
    SCRAP   : found
    PORTMIDI: not found
    PORTTIME: not found
    FREETYPE: not found
    Missing dependencies
```

This pull requests removes the specific version for pygame. I tested it and it looks to work as expected with pygame v1.9.4.
