### PR TITLE
Add a power bar to the player.

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -9,6 +9,14 @@ class Constants:
     # Basic colors
     WHITE = (255, 255, 255)
     BLACK = (0, 0, 0)
+    GREEN = (0, 255, 0)
+    RED = (255, 0, 0)
+
+    # UI Settings
+    HP = GREEN
+    DAMAGE = RED
+    INERT = BLACK
+    HP_BAR_HEIGHT = 10
 
     UPDATE_INTERVAL = 5000
 
@@ -91,4 +99,5 @@ class Layer:
     ENEMIES = 3
     ENEMY_BULLETS = 4
     POWER_UPS = 5
+    UI = 8
     EXPLOSIONS = 9

--- a/ff.py
+++ b/ff.py
@@ -7,6 +7,7 @@ from constants import Layer
 from src.Collisions import check_collisions
 from src.Sprites import Bullet
 from src.Sprites import Plane
+from src.Sprites import HealthBar
 from src.exceptions import LevelFinished, FormationEnd
 from src.map import Map
 
@@ -53,6 +54,9 @@ def create_player_plane(renderables):
     player_plane.rect.y = pygame.display.get_surface().get_height() - 100
     # Add player's plane to sprite list
     renderables.add(player_plane, layer=Layer.PLAYER)
+    # Add health bar to player.
+    hb = HealthBar(player_plane)
+    renderables.add(hb, layer=Layer.UI)
     return player_plane
 
 

--- a/src/Collisions/collisions.py
+++ b/src/Collisions/collisions.py
@@ -28,6 +28,8 @@ def check_collisions(renderables):
         # Draw explosion
         explosion = get_explosion(Constants.SPRITE_EXPLOSION, collision.rect)
         renderables.add(explosion)
+        # Reduce player HP to 0 so that the lifebar knows to finish animating and dying.
+        player_plane.hit_points = 0
         # Remove player's plane
         player_plane.kill()
         # Remove enemy plane

--- a/src/Sprites/__init__.py
+++ b/src/Sprites/__init__.py
@@ -5,3 +5,4 @@ from .boss import Boss
 from .bullet import Bullet
 from .explosion import Explosion
 from .horde import Horde
+from .health_bar import HealthBar

--- a/src/Sprites/health_bar.py
+++ b/src/Sprites/health_bar.py
@@ -1,0 +1,39 @@
+from pygame import Rect
+from pygame import Surface
+from pygame.draw import rect as draw_rect
+from pygame.sprite import Sprite
+
+from constants import Constants
+
+
+class HealthBar(Sprite):
+
+    def __init__(self, parent):
+        super().__init__()
+        self.parent = parent
+        self.max = self.parent.hit_points
+        self.hit_points = self.parent.hit_points
+
+    def update(self, *args):
+        if self.parent.hit_points < self.hit_points:
+            self.hit_points -= 0.5
+        if self.hit_points <= 0:
+            self.kill()
+
+    @property
+    def image(self):
+        width = self.parent.rect.width
+        height = Constants.HP_BAR_HEIGHT
+        img = Surface((width, height))
+        img.fill(Constants.INERT)
+        damage = int(self.hit_points / self.max * width)
+        draw_rect(img, Constants.DAMAGE, Rect(0, 0, damage, height))
+        health = int(self.parent.hit_points / self.max * width)
+        draw_rect(img, Constants.HP, Rect(0, 0, health, height))
+        return img
+
+    @property
+    def rect(self):
+        r = Rect(0, 0, self.parent.width, Constants.HP_BAR_HEIGHT)
+        r.midtop = self.parent.rect.midbottom
+        return r


### PR DESCRIPTION
I think this does what you're looking for in #1?

I wanted to minimize how much work this one does, so it only tracks its current HP and only draws when the `renderables` group asks for it.

I also had to add a line to the collisions to set the `player_ship`'s hp to zero so that it would finish rendering down HP and then disappear.

Also, I just put the UI layer high enough to be over most things, but figure that's a pretty arbitrary designation.