### PR TITLE
Enemy+Explosion sprites accumulate endlessly

### DIFF
--- a/src/Collisions/collisions.py
+++ b/src/Collisions/collisions.py
@@ -101,3 +101,8 @@ def delete_out_of_bounds_bullets(renderables):
     for bullet in enemy_bullets:
         if bullet.rect.y > pygame.display.get_surface().get_height():
             bullet.kill()
+
+    enemies = renderables.get_sprites_from_layer(Layer.ENEMIES)
+    for enemy in enemies:
+        if enemy.rect.y > pygame.display.get_surface().get_height():
+            enemy.kill()

--- a/src/Sprites/explosion.py
+++ b/src/Sprites/explosion.py
@@ -20,3 +20,5 @@ class Explosion(Sprite):
             self.image_index += 1
             if self.image_index < len(self.images):
                 self.image = self.images[self.image_index]
+            else:
+                self.kill()


### PR DESCRIPTION
If you play long enough, you're bound to run into overflowing issues.

Done:
* Killing explosion sprites after animation is done
* Killing enemy sprites after they leave the screen

Let me know if there are any issues with the PR!