### PR TITLE
Add start screen to game

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -86,12 +86,29 @@ class Constants:
 
     @staticmethod
     def get_available_text():
+        title = ArcadeFont(20).get_text("Welcome to Fuego Fighters",
+                                       (255, 0, 0))
+        start = ArcadeFont(15).get_text("When ready, press SPACE to start.",
+                                       (0, 0, 124))
         inst = ArcadeFont(15).get_text("Press SPACE to fire. Press 'q' to quit",
                                        (0, 0, 124))
         game_over = ArcadeFont(35).get_text("GAME OVER", (0, 0, 124))
+        
         restart = ArcadeFont(12).get_text(
             "Press 'r' to restart. Press 'q' to quit", (0, 0, 124))
+        quit = ArcadeFont(15).get_text("Press 'q' to quit", (0, 0, 124))
         available_text = {
+            "start_menu": {
+                "title":{
+                    'text': title,
+                    'pos': title.get_rect(center=(Constants.X_CENTER, 50))},
+                "start": {
+                    'text': start,
+                    'pos': start.get_rect(center=(Constants.X_CENTER, 550))},
+                "quit": {
+                    'text': quit,
+                    'pos': quit.get_rect(center=(Constants.X_CENTER, 720))}
+                },
             "instructions": {
                 'text': inst,
                 'pos': inst.get_rect(center=(Constants.X_CENTER, 50))},
@@ -101,11 +118,9 @@ class Constants:
             "restart": {
                 'text': restart,
                 'pos': restart.get_rect(center=(Constants.X_CENTER, 340))
-
             }
         }
         return available_text
-
 
 class Layer:
     PLAYER = 1

--- a/ff.py
+++ b/ff.py
@@ -35,6 +35,26 @@ def main():
     # update_map(renderables)
 
     mixer = Mixer(pygame.mixer)
+    
+    white=(255,255,255)
+    end_it=False
+    while (end_it==False):
+        screen.fill(white)
+        for event in pygame.event.get():
+            if pygame.key.get_pressed()[pygame.K_SPACE]:
+                end_it=True
+        pressed = pygame.key.get_pressed()
+        if pressed[pygame.K_q]:
+                exit(0)
+        for key in Constants.get_available_text()["start_menu"]:
+            screen.blit(    
+                    Constants.get_available_text()["start_menu"][key]['text'],
+                    Constants.get_available_text()["start_menu"][key]['pos']
+                )
+        screen.blit(player_plane.image, (Constants.X_CENTER-30, 275))
+        pygame.display.flip()
+
+    Constants.UPDATE_INTERVAL += pygame.time.get_ticks()
     while main_loop(clock, player_plane, renderables, screen, mixer):
         # Reset renderables in order to be able to loop again
         renderables = pygame.sprite.LayeredUpdates()


### PR DESCRIPTION
The games begins after opening and sometimes the player could just want to wait some time to start it. Don't know if you guys want that but think is a good idea to have a start screen. Looking to improve some other things like pause menu and volume control. 
One little question: The `hacktoberfest-accepted` tag can be added to the pr ? Would appreciate that.